### PR TITLE
README reformat

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# Hubot Rss Poller
+# Hubot RSS Poller
 
 This is a simple polling script used to poll RSS feeds and ping rooms when an
 update is found.  All it requires is a file specified to read.
 
-## Configuration 
+## Configuration
 
 All you need is a `.json` file with the following configurations set up.
 This is loaded from the `hubotrssconfig.json` file in the top level of the hubot
@@ -13,24 +13,29 @@ install, or you can specify in an environment variable `HUBOT_RSS_CONFIG_FILE`.
 {
   "feeds": [{
     "name": "Name of the RSS feed goes here",
-    "request": { // An object that contains the request parameters. Example not all inclusive
-    	"uri": "URI to the RSS feed goes here",
-	"headers": {
-		"Method": "GET"
-	}
+    "request": {
+      "uri": "URI to the RSS feed goes here",
+      "headers": {
+        "Method": "GET"
+      }
     },
     "room": "room to message out to when an update is found",
-    "pingInterval": "100", // How many seconds to wait before polling for update
+    "pingInterval": "100",
     "alertPrefix": "A prefix to the output message goes here.",
-    "alertSuffix": "a suffix to an output message goes here.",
-    "initialDelay": "3" // initial wait (in seconds) check to allow hubot to connect
+    "alertSuffix": "A suffix to the output message goes here.",
+    "initialDelay": "3"
   }]
 }
 ```
 
-##Basic Auth
+* `request` (object) - [request](https://github.com/request/request-promise) options
+* `pingInterval` (integer) - interval between polls in seconds.
+* `initialDelay` (integer) - delays RSS checks while hubot is starting.
+
+## Basic Auth
+
 You can specify `username` and `password` on an individual feed, or place them
-in the http Authorization header and they will work just fine.  But if you're
+in the HTTP Authorization header and they will work just fine.  But if you're
 like me and don't like having usernames and passwords sitting around in something
 that is probably source controlled, you can specify them via two environment
 variables.  `HUBOT_RSS_FEED_USERNAME` and `HUBOT_RSS_FEED_PASSWORD` act as global


### PR DESCRIPTION
- Move comments to below example JSON to make JSON valid
- Make auth header show up in Github Markdown

We've been using (a copy from npm of) this module for a while in our bot at xurizaemon/bolts, and only just discovered your actual module today. Submitting a few small fixes to say thanks and hi :grinning: 

Will switch xurizaemon/bolts over to this soon - once I've ported & submitted the features in xurizaemon/hubot-rss-poller2.