### PR TITLE
Update mocha to ^5.1.1 to address security vulnerability in dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,6 @@
     "eslint": "^2.6.0",
     "eslint-config-airbnb": "^7.0.0",
     "eslint-plugin-mocha": "^2.0.0",
-    "mocha": "^2.3.4"
+    "mocha": "^5.1.1"
   }
 }


### PR DESCRIPTION
- https://nodesecurity.io/advisories/118
- https://nodesecurity.io/advisories/146
- https://nodesecurity.io/advisories/534
